### PR TITLE
Add details about how to stop the server running

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ to have that installed.
 ### Standalone
 
 Download the [latest jar file](https://github.com/rksm/clj-org-analyzer/releases/latest)
-and run it! (double click or from command line, see below).
+and run it! (double click or from command line, see below). It will open a new browser window, if you close it the server will stop in a few seconds.
 
 ### Emacs
 


### PR DESCRIPTION
I wondered about how to stop the server when I don't need it anymore. I run the jar by double-clicking on it, but didn't know how to properly stop it. I realized that once you close the browser tab it sends a signal to the server and kills it in about 5 seconds.

I added that detail to the readme, because it wasn't obvious. Fixes #5 