### PR TITLE
Fix regexp to match non english timestamps

### DIFF
--- a/src/org_analyzer/processing.clj
+++ b/src/org_analyzer/processing.clj
@@ -25,7 +25,7 @@
 
 (def locales [Locale/ENGLISH Locale/GERMAN])
 
-(def timestamp-re #"([0-9]{4})-([0-9]{2})-([0-9]{2})\s+(?:[a-zA-Z]+\s+)?([0-9]{1,2}):([0-9]{1,2})")
+(def timestamp-re #"([0-9]{4})-([0-9]{2})-([0-9]{2})\s+(?:\S+\s+)?([0-9]{1,2}):([0-9]{1,2})")
 
 (defn parse-timestamp-manually [string]
   (let [[_ & year-month-day-hour-min] (re-find timestamp-re string)


### PR DESCRIPTION
Fixes #3 and fixes #1. As the group that matches the day name is a non-capturing group, I changed to match any non-whitespace characters. This should help parsing localized day names like `må.` or `mié.`.